### PR TITLE
default.py: xbmcgui.lock() and xbmcgui.unlock() are deprecated upstream

### DIFF
--- a/default.py
+++ b/default.py
@@ -27,7 +27,7 @@ from urlparse import parse_qs, urlparse
 from xml.dom.minidom import parseString
 from xbmc import translatePath
 import xbmcaddon
-from xbmcgui import Dialog, ListItem, lock, unlock
+from xbmcgui import Dialog, ListItem
 from xbmcplugin import addDirectoryItem, endOfDirectory
 
 Addon = xbmcaddon.Addon("plugin.audio.dradio")


### PR DESCRIPTION
https://github.com/xbmc/xbmc/pull/8160
